### PR TITLE
Fix 'remove' not working

### DIFF
--- a/src/formy.tsx
+++ b/src/formy.tsx
@@ -165,7 +165,7 @@ export function useFormy<T = any>(options: FormyParams<T> = {}): Formy<T> {
 
       Object.defineProperty(fieldProps, 'remove', {
         value: (index: number) => {
-          if (Array.isArray(getFieldValue(fieldPath))) {
+          if (!Array.isArray(getFieldValue(fieldPath))) {
             return
           }
 


### PR DESCRIPTION
Apparently this is a code that has been there for a long time, so I'm not 100% sure on my fix but it makes sense (also tested locally and only worked as expected when we added the `!`).

Basically we cannot remove from the array if it is not an array.